### PR TITLE
fix: declare --fields option in job:get command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,13 @@
   "bin": [
     "src/multiflexi-cli"
   ],
+  "require-dev": {
+    "ergebnis/composer-normalize": "^2.49",
+    "ergebnis/php-cs-fixer-config": "^6.58",
+    "friendsofphp/php-cs-fixer": "^3.92",
+    "phpstan/phpstan": "^2.1",
+    "phpunit/phpunit": "*"
+  },
   "config": {
     "allow-plugins": {
       "ergebnis/composer-normalize": true

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "ergebnis/php-cs-fixer-config": "^6.58",
     "friendsofphp/php-cs-fixer": "^3.92",
     "phpstan/phpstan": "^2.1",
-    "phpunit/phpunit": "*"
+    "phpunit/phpunit": "^13"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "283404535607cc088e7829a6cfa326f7",
+    "content-hash": "573406c6c6d44ae23238a1a11031ecb6",
     "packages": [
         {
             "name": "confirm-it-solutions/php-zabbix-api",
@@ -2124,12 +2124,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/VitexSoftware/php-ease-fluentpdo.git",
-                "reference": "60ee1c3f0f3d693792b1a281223857bc829cf708"
+                "reference": "a206067da3837d3994891cd7b13d0140d805161b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VitexSoftware/php-ease-fluentpdo/zipball/60ee1c3f0f3d693792b1a281223857bc829cf708",
-                "reference": "60ee1c3f0f3d693792b1a281223857bc829cf708",
+                "url": "https://api.github.com/repos/VitexSoftware/php-ease-fluentpdo/zipball/a206067da3837d3994891cd7b13d0140d805161b",
+                "reference": "a206067da3837d3994891cd7b13d0140d805161b",
                 "shasum": ""
             },
             "require": {
@@ -2177,7 +2177,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-04-21T13:19:07+00:00"
+            "time": "2026-05-05T19:01:25+00:00"
         },
         {
             "name": "vitexsoftware/ease-html",
@@ -2321,12 +2321,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/VitexSoftware/php-vitexsoftware-multiflexi-core.git",
-                "reference": "a25aa69e7d985374ba01ea5dd5470dfdfe19bb2b"
+                "reference": "ff7c05e757e8c18be13a6c6f38fac7a25a87822c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VitexSoftware/php-vitexsoftware-multiflexi-core/zipball/a25aa69e7d985374ba01ea5dd5470dfdfe19bb2b",
-                "reference": "a25aa69e7d985374ba01ea5dd5470dfdfe19bb2b",
+                "url": "https://api.github.com/repos/VitexSoftware/php-vitexsoftware-multiflexi-core/zipball/ff7c05e757e8c18be13a6c6f38fac7a25a87822c",
+                "reference": "ff7c05e757e8c18be13a6c6f38fac7a25a87822c",
                 "shasum": ""
             },
             "require": {
@@ -2373,7 +2373,7 @@
                 "issues": "https://github.com/VitexSoftware/php-vitexsoftware-multiflexi-core/issues",
                 "source": "https://github.com/VitexSoftware/php-vitexsoftware-multiflexi-core/tree/main"
             },
-            "time": "2026-04-28T19:43:40+00:00"
+            "time": "2026-05-05T19:54:47+00:00"
         }
     ],
     "packages-dev": [
@@ -3906,8 +3906,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bf01c3c556d652e280f5df7a5503275769bd36fd",
-                "reference": "bf01c3c556d652e280f5df7a5503275769bd36fd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/77f24c00c06aaaf28cacd4131fd9d9a56f3dd21e",
+                "reference": "77f24c00c06aaaf28cacd4131fd9d9a56f3dd21e",
                 "shasum": ""
             },
             "require": {
@@ -3964,7 +3964,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-05T07:56:13+00:00"
+            "time": "2026-05-05T18:35:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4360,12 +4360,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "11cb417d6d90a4d0dc13233f46871d2ed47f8ed7"
+                "reference": "6301da994fddabd3fe9f20ee2f789360723b5dd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/11cb417d6d90a4d0dc13233f46871d2ed47f8ed7",
-                "reference": "11cb417d6d90a4d0dc13233f46871d2ed47f8ed7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6301da994fddabd3fe9f20ee2f789360723b5dd8",
+                "reference": "6301da994fddabd3fe9f20ee2f789360723b5dd8",
                 "shasum": ""
             },
             "require": {
@@ -4445,7 +4445,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-05T07:16:15+00:00"
+            "time": "2026-05-05T10:25:05+00:00"
         },
         {
             "name": "psr/event-dispatcher",

--- a/composer.lock
+++ b/composer.lock
@@ -85,6 +85,71 @@
             "time": "2021-06-15T18:58:00+00:00"
         },
         {
+            "name": "dragonmantank/cron-expression",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dragonmantank/cron-expression.git",
+                "reference": "d425a2403c17d7cf911c55a7170f073979a9f382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dragonmantank/cron-expression/zipball/d425a2403c17d7cf911c55a7170f073979a9f382",
+                "reference": "d425a2403c17d7cf911c55a7170f073979a9f382",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2|^8.3|^8.4|^8.5"
+            },
+            "replace": {
+                "mtdowling/cron-expression": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.31",
+                "phpunit/phpunit": "^11.5.43 || ^12.4"
+            },
+            "default-branch": true,
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cron\\": "src/Cron/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Tankersley",
+                    "email": "chris@ctankersley.com",
+                    "homepage": "https://github.com/dragonmantank"
+                }
+            ],
+            "description": "CRON for PHP: Calculate the next or previous run date and determine if a CRON expression is due",
+            "keywords": [
+                "cron",
+                "schedule"
+            ],
+            "support": {
+                "issues": "https://github.com/dragonmantank/cron-expression/issues",
+                "source": "https://github.com/dragonmantank/cron-expression/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dragonmantank",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-20T20:18:24+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "7.10.x-dev",
             "source": {
@@ -450,16 +515,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.8.0",
+            "version": "6.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "89ac92bcfe5d0a8a4433c7b89d394553ae7250cc"
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/89ac92bcfe5d0a8a4433c7b89d394553ae7250cc",
-                "reference": "89ac92bcfe5d0a8a4433c7b89d394553ae7250cc",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
                 "shasum": ""
             },
             "require": {
@@ -469,7 +534,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.3.0",
-                "json-schema/json-schema-test-suite": "^23.2",
+                "json-schema/json-schema-test-suite": "dev-main",
                 "marc-mabe/php-enum-phpstan": "^2.0",
                 "phpspec/prophecy": "^1.19",
                 "phpstan/phpstan": "^1.12",
@@ -519,9 +584,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
             },
-            "time": "2026-04-02T12:43:11+00:00"
+            "time": "2026-05-05T05:39:01+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -1495,12 +1560,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
-                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -1570,7 +1635,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T16:19:22+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
@@ -2256,15 +2321,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/VitexSoftware/php-vitexsoftware-multiflexi-core.git",
-                "reference": "4a25d18408db582e541d46ad9bb299a0c9fa135f"
+                "reference": "a25aa69e7d985374ba01ea5dd5470dfdfe19bb2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/VitexSoftware/php-vitexsoftware-multiflexi-core/zipball/4a25d18408db582e541d46ad9bb299a0c9fa135f",
-                "reference": "4a25d18408db582e541d46ad9bb299a0c9fa135f",
+                "url": "https://api.github.com/repos/VitexSoftware/php-vitexsoftware-multiflexi-core/zipball/a25aa69e7d985374ba01ea5dd5470dfdfe19bb2b",
+                "reference": "a25aa69e7d985374ba01ea5dd5470dfdfe19bb2b",
                 "shasum": ""
             },
             "require": {
+                "dragonmantank/cron-expression": "^3.3",
                 "jalismrs/bitwarden-php": "^1.1",
                 "justinrainbow/json-schema": "^6.6@dev",
                 "vitexsoftware/ease-core": "^1.50",
@@ -2289,6 +2355,7 @@
                     "MultiFlexi\\Action\\": "src/MultiFlexi/Action",
                     "MultiFlexi\\Zabbix\\": "src/MultiFlexi/Zabbix",
                     "MultiFlexi\\Executor\\": "src/MultiFlexi/Executor",
+                    "MultiFlexi\\Reporting\\": "src/MultiFlexi/Reporting",
                     "MultiFlexi\\CredentialProtoType\\": "src/MultiFlexi/CredentialProtoType"
                 }
             },
@@ -2306,7 +2373,7 @@
                 "issues": "https://github.com/VitexSoftware/php-vitexsoftware-multiflexi-core/issues",
                 "source": "https://github.com/VitexSoftware/php-vitexsoftware-multiflexi-core/tree/main"
             },
-            "time": "2026-04-22T05:08:09+00:00"
+            "time": "2026-04-28T19:43:40+00:00"
         }
     ],
     "packages-dev": [
@@ -3839,8 +3906,8 @@
             "version": "2.2.x-dev",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1b641bd1331022abaa566c8577d08089a9c891cb",
-                "reference": "1b641bd1331022abaa566c8577d08089a9c891cb",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bf01c3c556d652e280f5df7a5503275769bd36fd",
+                "reference": "bf01c3c556d652e280f5df7a5503275769bd36fd",
                 "shasum": ""
             },
             "require": {
@@ -3897,7 +3964,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-22T07:02:28+00:00"
+            "time": "2026-05-05T07:56:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3905,17 +3972,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "24dc6fcf9f2a983de5b3f1199fb01e88d68e7474"
+                "reference": "5e97bbec7d0adb2b5a02991f0cab98e007da829b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/24dc6fcf9f2a983de5b3f1199fb01e88d68e7474",
-                "reference": "24dc6fcf9f2a983de5b3f1199fb01e88d68e7474",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5e97bbec7d0adb2b5a02991f0cab98e007da829b",
+                "reference": "5e97bbec7d0adb2b5a02991f0cab98e007da829b",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
+                "ext-mbstring": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.4",
@@ -3938,7 +4006,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "14.1.x-dev"
+                    "dev-main": "14.2.x-dev"
                 }
             },
             "autoload": {
@@ -3967,7 +4035,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.1.3"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/main"
             },
             "funding": [
                 {
@@ -3987,7 +4055,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T05:41:54+00:00"
+            "time": "2026-05-05T05:02:39+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3995,12 +4063,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "c8043742d95bffe56e3dce5d680d2b24649bee8a"
+                "reference": "4e706f8a080ca1aadaa3372be8df90048313ab2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/c8043742d95bffe56e3dce5d680d2b24649bee8a",
-                "reference": "c8043742d95bffe56e3dce5d680d2b24649bee8a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4e706f8a080ca1aadaa3372be8df90048313ab2d",
+                "reference": "4e706f8a080ca1aadaa3372be8df90048313ab2d",
                 "shasum": ""
             },
             "require": {
@@ -4061,7 +4129,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:44:02+00:00"
+            "time": "2026-05-01T06:40:43+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -4069,12 +4137,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "530babcb480a232c16a8a946adc69c21ebaea4fe"
+                "reference": "10d62aae3cd95c8e75ffdff57b20db15753f7ed9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/530babcb480a232c16a8a946adc69c21ebaea4fe",
-                "reference": "530babcb480a232c16a8a946adc69c21ebaea4fe",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/10d62aae3cd95c8e75ffdff57b20db15753f7ed9",
+                "reference": "10d62aae3cd95c8e75ffdff57b20db15753f7ed9",
                 "shasum": ""
             },
             "require": {
@@ -4138,7 +4206,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:45:51+00:00"
+            "time": "2026-05-01T06:40:50+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -4146,12 +4214,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "d7668315f103e3388f2e7555f7b4c6dfcae8fe06"
+                "reference": "6fd0bfea3df861e0fc35657dee2efea3459d92db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/d7668315f103e3388f2e7555f7b4c6dfcae8fe06",
-                "reference": "d7668315f103e3388f2e7555f7b4c6dfcae8fe06",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/6fd0bfea3df861e0fc35657dee2efea3459d92db",
+                "reference": "6fd0bfea3df861e0fc35657dee2efea3459d92db",
                 "shasum": ""
             },
             "require": {
@@ -4211,7 +4279,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:47:08+00:00"
+            "time": "2026-05-01T06:40:55+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -4219,12 +4287,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "83e6712e2efabd643d2e3214752ac39696bc9c4f"
+                "reference": "798cc9c6e643caedeb37692c2aeac8a523bda51b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/83e6712e2efabd643d2e3214752ac39696bc9c4f",
-                "reference": "83e6712e2efabd643d2e3214752ac39696bc9c4f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/798cc9c6e643caedeb37692c2aeac8a523bda51b",
+                "reference": "798cc9c6e643caedeb37692c2aeac8a523bda51b",
                 "shasum": ""
             },
             "require": {
@@ -4284,7 +4352,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:48:31+00:00"
+            "time": "2026-05-01T06:41:02+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -4292,12 +4360,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d9083d3f7f0d505985814a70d7b6b8402ce0be62"
+                "reference": "11cb417d6d90a4d0dc13233f46871d2ed47f8ed7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d9083d3f7f0d505985814a70d7b6b8402ce0be62",
-                "reference": "d9083d3f7f0d505985814a70d7b6b8402ce0be62",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/11cb417d6d90a4d0dc13233f46871d2ed47f8ed7",
+                "reference": "11cb417d6d90a4d0dc13233f46871d2ed47f8ed7",
                 "shasum": ""
             },
             "require": {
@@ -4311,7 +4379,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.1.3",
+                "phpunit/php-code-coverage": "^14.2",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
@@ -4377,7 +4445,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-22T11:15:18+00:00"
+            "time": "2026-05-05T07:16:15+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -5016,12 +5084,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "ba596ee460463718c1fa3e296aca044c62ec2f5b"
+                "reference": "ac8d52776715a8822f291b501da7d79090bba5a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/ba596ee460463718c1fa3e296aca044c62ec2f5b",
-                "reference": "ba596ee460463718c1fa3e296aca044c62ec2f5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/ac8d52776715a8822f291b501da7d79090bba5a3",
+                "reference": "ac8d52776715a8822f291b501da7d79090bba5a3",
                 "shasum": ""
             },
             "require": {
@@ -5078,7 +5146,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:07:08+00:00"
+            "time": "2026-05-01T06:38:12+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -5086,12 +5154,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1"
+                "reference": "29b1b8fea562c7c37c9b90d63f2a5daa9d3a8eb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
-                "reference": "b3d09f4360ad97dcad8f82d1c047ad16ff38b7e1",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/29b1b8fea562c7c37c9b90d63f2a5daa9d3a8eb2",
+                "reference": "29b1b8fea562c7c37c9b90d63f2a5daa9d3a8eb2",
                 "shasum": ""
             },
             "require": {
@@ -5151,7 +5219,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/8.1.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/main"
             },
             "funding": [
                 {
@@ -5171,7 +5239,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-14T08:24:42+00:00"
+            "time": "2026-05-01T06:38:30+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -5179,12 +5247,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "8c41d0367b9fe9abef8aa8f7863b4a9d41644a25"
+                "reference": "b83c784ed086c45f3881a07bc1f460cca957f0cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/8c41d0367b9fe9abef8aa8f7863b4a9d41644a25",
-                "reference": "8c41d0367b9fe9abef8aa8f7863b4a9d41644a25",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/b83c784ed086c45f3881a07bc1f460cca957f0cc",
+                "reference": "b83c784ed086c45f3881a07bc1f460cca957f0cc",
                 "shasum": ""
             },
             "require": {
@@ -5242,7 +5310,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:11:52+00:00"
+            "time": "2026-05-01T06:38:59+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5250,12 +5318,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "a48c1309ef3395055b8ec970b3fe45dc46cf888b"
+                "reference": "15cd80c7330aabb390c329dc133ac14082a83347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/a48c1309ef3395055b8ec970b3fe45dc46cf888b",
-                "reference": "a48c1309ef3395055b8ec970b3fe45dc46cf888b",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/15cd80c7330aabb390c329dc133ac14082a83347",
+                "reference": "15cd80c7330aabb390c329dc133ac14082a83347",
                 "shasum": ""
             },
             "require": {
@@ -5322,7 +5390,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:15:00+00:00"
+            "time": "2026-05-01T06:39:22+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -5330,12 +5398,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6767059a30e4277ac95ee034809e793528464768"
+                "reference": "aa82a42778b2af14116d181662a1749bfb08581f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6767059a30e4277ac95ee034809e793528464768",
-                "reference": "6767059a30e4277ac95ee034809e793528464768",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/aa82a42778b2af14116d181662a1749bfb08581f",
+                "reference": "aa82a42778b2af14116d181662a1749bfb08581f",
                 "shasum": ""
             },
             "require": {
@@ -5379,7 +5447,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/main"
             },
             "funding": [
                 {
@@ -5399,7 +5467,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:14:03+00:00"
+            "time": "2026-05-01T06:39:27+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -5407,12 +5475,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb"
+                "reference": "e8c1311f17761e79d260ed5e809721e15eaab3b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
-                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/e8c1311f17761e79d260ed5e809721e15eaab3b6",
+                "reference": "e8c1311f17761e79d260ed5e809721e15eaab3b6",
                 "shasum": ""
             },
             "require": {
@@ -5470,7 +5538,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/main"
             },
             "funding": [
                 {
@@ -5490,7 +5558,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:38:05+00:00"
+            "time": "2026-05-01T06:39:35+00:00"
         },
         {
             "name": "sebastian/file-filter",
@@ -5498,12 +5566,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/file-filter.git",
-                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93"
+                "reference": "81d2faea800da2613a0a5aa2c8168c09d2d9e0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/33a26f394330f6faa7684bb9cc73afb7727aae93",
-                "reference": "33a26f394330f6faa7684bb9cc73afb7727aae93",
+                "url": "https://api.github.com/repos/sebastianbergmann/file-filter/zipball/81d2faea800da2613a0a5aa2c8168c09d2d9e0b2",
+                "reference": "81d2faea800da2613a0a5aa2c8168c09d2d9e0b2",
                 "shasum": ""
             },
             "require": {
@@ -5540,7 +5608,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/file-filter/issues",
                 "security": "https://github.com/sebastianbergmann/file-filter/security/policy",
-                "source": "https://github.com/sebastianbergmann/file-filter/tree/1.0.0"
+                "source": "https://github.com/sebastianbergmann/file-filter/tree/main"
             },
             "funding": [
                 {
@@ -5560,7 +5628,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T07:20:04+00:00"
+            "time": "2026-05-01T06:39:40+00:00"
         },
         {
             "name": "sebastian/git-state",
@@ -5568,12 +5636,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/git-state.git",
-                "reference": "fbf94767fc0406140c9197b34ad7b4e6d1ce504a"
+                "reference": "29bac4984279175be539582e9de9c1a587870306"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/fbf94767fc0406140c9197b34ad7b4e6d1ce504a",
-                "reference": "fbf94767fc0406140c9197b34ad7b4e6d1ce504a",
+                "url": "https://api.github.com/repos/sebastianbergmann/git-state/zipball/29bac4984279175be539582e9de9c1a587870306",
+                "reference": "29bac4984279175be539582e9de9c1a587870306",
                 "shasum": ""
             },
             "require": {
@@ -5630,7 +5698,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:20:36+00:00"
+            "time": "2026-05-01T06:39:49+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -5638,12 +5706,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0e3d3c877f648e6f5b3d9432f35023c8e0ab1c01"
+                "reference": "ee6d6cca9cfd29668fe17780c39ffe42cb3f8083"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0e3d3c877f648e6f5b3d9432f35023c8e0ab1c01",
-                "reference": "0e3d3c877f648e6f5b3d9432f35023c8e0ab1c01",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/ee6d6cca9cfd29668fe17780c39ffe42cb3f8083",
+                "reference": "ee6d6cca9cfd29668fe17780c39ffe42cb3f8083",
                 "shasum": ""
             },
             "require": {
@@ -5705,7 +5773,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:22:24+00:00"
+            "time": "2026-05-01T06:39:53+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -5713,12 +5781,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "10fa69ed9aabc6957846314b32f9345a1ecbb58f"
+                "reference": "9c018e947c0740e60d9518770e6f520c8cc85b2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/10fa69ed9aabc6957846314b32f9345a1ecbb58f",
-                "reference": "10fa69ed9aabc6957846314b32f9345a1ecbb58f",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/9c018e947c0740e60d9518770e6f520c8cc85b2c",
+                "reference": "9c018e947c0740e60d9518770e6f520c8cc85b2c",
                 "shasum": ""
             },
             "require": {
@@ -5776,7 +5844,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:23:59+00:00"
+            "time": "2026-05-01T06:40:03+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -5784,12 +5852,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "24563dc65deec0745ea33664be5dcfe7f1ad9e89"
+                "reference": "7fa5e6fa4cdf2836db9e7afb5e3ddc7ca334c767"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/24563dc65deec0745ea33664be5dcfe7f1ad9e89",
-                "reference": "24563dc65deec0745ea33664be5dcfe7f1ad9e89",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7fa5e6fa4cdf2836db9e7afb5e3ddc7ca334c767",
+                "reference": "7fa5e6fa4cdf2836db9e7afb5e3ddc7ca334c767",
                 "shasum": ""
             },
             "require": {
@@ -5847,7 +5915,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:35:43+00:00"
+            "time": "2026-05-01T06:40:14+00:00"
         },
         {
             "name": "sebastian/object-reflector",
@@ -5855,12 +5923,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "e54984e4148522b1183d63f7643069d4235b862f"
+                "reference": "3c0ccb72303f35398735e739eae9340f49135d66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/e54984e4148522b1183d63f7643069d4235b862f",
-                "reference": "e54984e4148522b1183d63f7643069d4235b862f",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/3c0ccb72303f35398735e739eae9340f49135d66",
+                "reference": "3c0ccb72303f35398735e739eae9340f49135d66",
                 "shasum": ""
             },
             "require": {
@@ -5916,7 +5984,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:38:04+00:00"
+            "time": "2026-05-01T06:40:19+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -5924,12 +5992,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f2453988086768d679e469e458db3b0dcaec700a"
+                "reference": "34c9c883c0c7757abb1531dc7efd4561e1625c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f2453988086768d679e469e458db3b0dcaec700a",
-                "reference": "f2453988086768d679e469e458db3b0dcaec700a",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/34c9c883c0c7757abb1531dc7efd4561e1625c65",
+                "reference": "34c9c883c0c7757abb1531dc7efd4561e1625c65",
                 "shasum": ""
             },
             "require": {
@@ -5993,7 +6061,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:51:30+00:00"
+            "time": "2026-05-01T06:41:13+00:00"
         },
         {
             "name": "sebastian/type",
@@ -6001,12 +6069,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "3e2202afd0a2c4487b4e8a3e58c3bcd237a1516d"
+                "reference": "e5d90569a3b8611ea6e3c5892485bc777c00a80b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3e2202afd0a2c4487b4e8a3e58c3bcd237a1516d",
-                "reference": "3e2202afd0a2c4487b4e8a3e58c3bcd237a1516d",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/e5d90569a3b8611ea6e3c5892485bc777c00a80b",
+                "reference": "e5d90569a3b8611ea6e3c5892485bc777c00a80b",
                 "shasum": ""
             },
             "require": {
@@ -6063,7 +6131,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:53:01+00:00"
+            "time": "2026-05-01T06:43:47+00:00"
         },
         {
             "name": "sebastian/version",
@@ -6071,12 +6139,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "7f5834dddc5226c26184f69715f4a61039737199"
+                "reference": "3670e8041078911c75cca838a56a53ae41b11449"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/7f5834dddc5226c26184f69715f4a61039737199",
-                "reference": "7f5834dddc5226c26184f69715f4a61039737199",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3670e8041078911c75cca838a56a53ae41b11449",
+                "reference": "3670e8041078911c75cca838a56a53ae41b11449",
                 "shasum": ""
             },
             "require": {
@@ -6130,7 +6198,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T05:54:46+00:00"
+            "time": "2026-05-01T06:41:40+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -6358,12 +6426,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "2c8e7a47bbc5f30f950c615f02fe341a05416c12"
+                "reference": "5f0d8cd5c9d398fc5d1d2355144e1baf94b50fcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2c8e7a47bbc5f30f950c615f02fe341a05416c12",
-                "reference": "2c8e7a47bbc5f30f950c615f02fe341a05416c12",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5f0d8cd5c9d398fc5d1d2355144e1baf94b50fcf",
+                "reference": "5f0d8cd5c9d398fc5d1d2355144e1baf94b50fcf",
                 "shasum": ""
             },
             "require": {
@@ -6422,7 +6490,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-09T14:06:24+00:00"
+            "time": "2026-04-18T13:52:23+00:00"
         },
         {
             "name": "symfony/finder",

--- a/debian/cz.vitexsoftware.multiflexi-cli.metainfo.xml
+++ b/debian/cz.vitexsoftware.multiflexi-cli.metainfo.xml
@@ -10,6 +10,7 @@
       MultiFlexi CLI is a powerful command-line interface tool for managing and interacting with the MultiFlexi system. It allows administrators and users to list, create, get, and delete MultiFlexi resources directly from the terminal. </p> <p> The CLI supports JSON output for easy integration with other tools and scripts, and provides internationalization support. This package is intended for users who prefer or require command-line access to MultiFlexi's features.
     </p>
   </description>
+  <icon type="stock">multiflexi-cli</icon>
   <categories>
     <category>System</category>
     <category>ConsoleOnly</category>

--- a/debian/multiflexi-cli.install
+++ b/debian/multiflexi-cli.install
@@ -5,4 +5,5 @@ src/MultiFlexi/*.php        usr/lib/multiflexi-cli/MultiFlexi/
 src/MultiFlexi/Cli/*.php    usr/lib/multiflexi-cli/MultiFlexi/Cli/
 debian/tmp/composer.json    usr/lib/multiflexi-cli
 debian/cz.vitexsoftware.multiflexi-cli.metainfo.xml usr/share/metainfo/
+multiflexi-cli.svg          usr/share/icons/hicolor/scalable/apps/
 debian/sudoers.d/*          etc/sudoers.d/

--- a/multiflexi-cli.svg
+++ b/multiflexi-cli.svg
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   id="svg3041"
+   sodipodi:docname="multiflexi-cli.svg"
+   viewBox="0 0 468.75 468.74998"
+   version="1.1"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   width="500"
+   height="500"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs26">
+    <linearGradient
+       id="linearGradient3235">
+      <stop
+         id="stop3237"
+         style="stop-color:#ffffff"
+         offset="0" />
+      <stop
+         id="stop3247"
+         style="stop-color:#43ff38"
+         offset=".26786" />
+      <stop
+         id="stop3239"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient5217"
+       xlink:href="#linearGradient3235"
+       gradientUnits="userSpaceOnUse"
+       cy="507.57999"
+       cx="544.67999"
+       gradientTransform="matrix(0.6462,0,0,0.37308,192.71,318.21)"
+       r="7.6715002"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3282">
+      <stop
+         id="stop3284"
+         style="stop-color:#ffffff;stop-opacity:.29412"
+         offset="0" />
+      <stop
+         id="stop3286"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4143">
+      <stop
+         style="stop-color:#c3c3c3;stop-opacity:1;"
+         offset="0"
+         id="stop4145" />
+      <stop
+         style="stop-color:#f3f3f3;stop-opacity:1;"
+         offset="1"
+         id="stop4147" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3844-7">
+      <stop
+         style="stop-color:#997979;stop-opacity:1;"
+         offset="0"
+         id="stop3846-4" />
+      <stop
+         style="stop-color:#483737;stop-opacity:1;"
+         offset="1"
+         id="stop3848-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3844-7"
+       id="radialGradient510"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.37357961,0,383.43584)"
+       cx="397.23151"
+       cy="600.68091"
+       fx="397.23151"
+       fy="600.68091"
+       r="26.083048" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3844-7"
+       id="radialGradient518"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.37357961,0,383.43584)"
+       cx="397.23151"
+       cy="600.68091"
+       fx="397.23151"
+       fy="600.68091"
+       r="26.083048" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3844-7"
+       id="radialGradient526"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.37357961,0,383.43584)"
+       cx="397.23151"
+       cy="600.68091"
+       fx="397.23151"
+       fy="600.68091"
+       r="26.083048" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3844-7"
+       id="radialGradient534"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.37357961,0,383.43584)"
+       cx="397.23151"
+       cy="600.68091"
+       fx="397.23151"
+       fy="600.68091"
+       r="26.083048" />
+    <linearGradient
+       id="linearGradient4083">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30303031;"
+         offset="0"
+         id="stop4085" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4087" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4139">
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:0.17424242;"
+         offset="0"
+         id="stop4141" />
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:0.0530303;"
+         offset="1"
+         id="stop4143" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 64.09713,512 H 447.9029 c 22.2879,0 30.3701,-2.3206 38.5182,-6.6783 8.1482,-4.3577 14.5429,-10.7524 18.9006,-18.9006 C 509.6794,478.273 512,470.1908 512,447.9029 V 64.09713 C 512,41.80916 509.6794,33.72701 505.3217,25.57886 500.964,17.43071 494.5693,11.03599 486.4211,6.678318 478.273,2.32064 470.1908,0 447.9029,0 H 64.09713 C 41.80916,0 33.72701,2.32064 25.57886,6.678318 17.43071,11.03599 11.03599,17.43071 6.678318,25.57886 2.32064,33.72701 0,41.80916 0,64.09713 V 447.9029 c 0,22.2879 2.32064,30.3701 6.678318,38.5182 4.357672,8.1482 10.752392,14.5429 18.900542,18.9006 8.14815,4.3577 16.2303,6.6783 38.51827,6.6783 z"
+         clip-rule="evenodd"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 0,0 H 512 V 512 H 0 Z"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 310.6214,362 424.7089,162.0939 H 310.6961 l -57.0086,99.4988 z"
+         clip-rule="evenodd"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 0,0 H 512 V 512 H 0 Z"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 197.1006,362 83.51535,162.0939 H 197.1006 L 310.6214,362 Z"
+         clip-rule="evenodd"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 0,0 H 512 V 512 H 0 Z"
+         id="path403" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient2212"
+       y2="14.158"
+       gradientUnits="userSpaceOnUse"
+       x2="24.841999"
+       gradientTransform="matrix(0.95741,0,0,0.95233,1.0228,0.13331)"
+       y1="32.285999"
+       x1="29.870001"
+       inkscape:collect="always">
+      <stop
+         id="stop2208"
+         style="stop-color:#777973"
+         offset="0" />
+      <stop
+         id="stop2210"
+         style="stop-color:#cbccca"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2220"
+       y2="32.498001"
+       gradientUnits="userSpaceOnUse"
+       x2="21.305"
+       gradientTransform="matrix(0.95741,0,0,0.95233,1.0228,0.13331)"
+       y1="9.5865002"
+       x1="8.6528997"
+       inkscape:collect="always">
+      <stop
+         id="stop5178"
+         style="stop-color:#a2a59c"
+         offset="0" />
+      <stop
+         id="stop5180"
+         style="stop-color:#535750"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2244"
+       y2="49.730999"
+       gradientUnits="userSpaceOnUse"
+       x2="48.845001"
+       gradientTransform="matrix(0.95351,0,0,0.94787,1.1415,1.2056)"
+       y1="19.636999"
+       x1="20.339001"
+       inkscape:collect="always">
+      <stop
+         id="stop2240"
+         style="stop-color:#ffffff"
+         offset="0" />
+      <stop
+         id="stop2242"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <filter
+       inkscape:label="Black Hole"
+       inkscape:menu="Morphology"
+       inkscape:menu-tooltip="Creates a black light inside and outside"
+       height="1.0441137"
+       width="1.0594339"
+       y="-0.022056837"
+       x="-0.029716946"
+       style="color-interpolation-filters:sRGB"
+       id="filter776">
+      <feGaussianBlur
+         stdDeviation="5"
+         in="SourceAlpha"
+         result="result1"
+         id="feGaussianBlur764" />
+      <feComposite
+         operator="arithmetic"
+         k2="3.2"
+         k1="-1"
+         k4="-2"
+         result="result3"
+         in2="result1"
+         id="feComposite766"
+         k3="0" />
+      <feColorMatrix
+         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 10 0 "
+         result="result2"
+         id="feColorMatrix768" />
+      <feComposite
+         result="fbSourceGraphic"
+         in="SourceGraphic"
+         operator="out"
+         in2="result2"
+         id="feComposite770" />
+      <feBlend
+         mode="multiply"
+         in="result1"
+         in2="fbSourceGraphic"
+         result="result91"
+         id="feBlend772" />
+      <feBlend
+         mode="screen"
+         in="fbSourceGraphic"
+         in2="result91"
+         id="feBlend774" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     bordercolor="#666666"
+     inkscape:pageshadow="2"
+     inkscape:window-y="0"
+     fit-margin-left="0"
+     pagecolor="#ffffff"
+     fit-margin-top="0"
+     inkscape:window-maximized="1"
+     inkscape:zoom="0.46665767"
+     inkscape:window-x="0"
+     inkscape:window-height="1120"
+     showgrid="false"
+     borderopacity="1.0"
+     inkscape:current-layer="layer1"
+     inkscape:cx="-123.21666"
+     inkscape:cy="324.64912"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1920"
+     inkscape:pageopacity="0.0"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(-44.3965,-11.398655)">
+    <g
+       id="g9460"
+       transform="matrix(10.094243,0,0,10.094243,36.503615,13.594954)"
+       inkscape:export-filename="F:\command_line.png"
+       inkscape:export-xdpi="48"
+       inkscape:export-ydpi="48">
+      <rect
+         id="rect1316"
+         style="display:inline;fill:url(#linearGradient2212);fill-rule:evenodd;stroke:url(#linearGradient2220);stroke-linecap:round;stroke-linejoin:round"
+         rx="4.8516998"
+         ry="4.8516998"
+         height="38.999001"
+         width="44.995998"
+         y="3.5016"
+         x="1.5026" />
+      <rect
+         id="rect1314"
+         style="display:inline;fill:#020201;fill-opacity:1;fill-rule:evenodd;stroke:#616161;stroke-width:0.99496;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         rx="1.6452"
+         ry="1.6452"
+         height="29.021999"
+         width="37.088001"
+         y="7.4826999"
+         x="5.4963002" />
+      <rect
+         id="rect2232"
+         style="display:inline;opacity:0.76374;fill:none;stroke:url(#linearGradient2244);stroke-linecap:round;stroke-linejoin:round"
+         rx="3.7909999"
+         ry="3.7909999"
+         height="37.000999"
+         width="42.945"
+         y="4.5007"
+         x="2.5543001" />
+      <path
+         id="text1340"
+         sodipodi:nodetypes="ccccccccccccc"
+         style="fill:#ffffff;stroke:#6ed66e;stroke-width:1pt;stroke-opacity:0.27869"
+         d="m 11.625,20.679 v -3.054 l 8.985,4.061 v 1.856 l -8.985,4.087 V 24.584 L 18.589,22.73 Z M 30.518,30.706 V 32.68 H 19.614 v -1.974 h 10.904" />
+    </g>
+    <g
+       id="g249"
+       transform="matrix(0.32939742,0,0,0.32939742,97.473877,52.332051)"
+       style="fill:#ffd42a;fill-opacity:1;filter:url(#filter776)">
+      <path
+         id="path5740"
+         style="color:#000000;text-indent:0;text-transform:none;fill:#ffd42a;fill-opacity:1;fill-rule:evenodd"
+         inkscape:connector-curvature="0"
+         d="m 713.47,204.89 v 74.226 c -91.83,18.86 -161.52,100.63 -161.52,197.79 0,96.668 69.012,178.12 160.15,197.51 L 645.092,607.408 686.15,566.35 c -26.951,-20.333 -44.214,-52.667 -44.214,-89.444 0,-48.051 29.471,-88.501 71.524,-104.52 v 115.53 L 854.98,346.396 713.47,204.886 Z" />
+      <path
+         id="path2985"
+         style="color:#000000;text-indent:0;text-transform:none;fill:#ffd42a;fill-opacity:1;fill-rule:evenodd"
+         inkscape:connector-curvature="0"
+         d="m 795.61,279.41 67.008,66.993 -41.074,41.074 c 26.961,20.328 44.23,52.647 44.23,89.428 0,48.051 -29.47,88.512 -71.524,104.54 v -115.55 l -141.52,141.52 141.52,141.52 v -74.226 c 91.812,-18.87 161.51,-100.65 161.51,-197.79 0,-96.667 -69.01,-178.1 -160.15,-197.49 z" />
+    </g>
+  </g>
+  <metadata
+     id="metadata23">
+    <rdf:RDF>
+      <cc:Work>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:publisher>
+          <cc:Agent
+             rdf:about="http://openclipart.org/">
+            <dc:title>Openclipart</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:date>2012-01-07T08:22:20</dc:date>
+        <dc:description>Help desk</dc:description>
+        <dc:source>https://openclipart.org/detail/166905/help-desk-by-gsagri04</dc:source>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>gsagri04</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Help</rdf:li>
+            <rdf:li>care</rdf:li>
+            <rdf:li>corporate</rdf:li>
+            <rdf:li>customer</rdf:li>
+            <rdf:li>desk</rdf:li>
+            <rdf:li>office</rdf:li>
+            <rdf:li>reception</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Command/CompanyAppCommand.php
+++ b/src/Command/CompanyAppCommand.php
@@ -121,7 +121,6 @@ class CompanyAppCommand extends MultiFlexiCommand
                     : $output->writeln(self::outputTable($runtemplates));
 
                 return Command::SUCCESS;
-
             case 'assign':
                 if (empty($companyId) || empty($appId)) {
                     $msg = '--company_id and either --app_id or --app_uuid are required for assign.';
@@ -184,7 +183,6 @@ class CompanyAppCommand extends MultiFlexiCommand
                     : $output->writeln("Application {$appId} ({$appName}) assigned to company {$companyId}, RunTemplate {$rtId} created.");
 
                 return Command::SUCCESS;
-
             case 'unassign':
                 if (empty($companyId) || empty($appId)) {
                     $msg = '--company_id and either --app_id or --app_uuid are required for unassign.';

--- a/src/Command/Encryption/InitCommand.php
+++ b/src/Command/Encryption/InitCommand.php
@@ -70,7 +70,7 @@ class InitCommand extends BaseCommand
             $insertStmt = $pdo->prepare(<<<'EOD'
 INSERT INTO encryption_keys (key_name, key_data, algorithm, created_at, is_active)
                  VALUES ('credentials', :key_data, 'aes-256-gcm', NOW(), TRUE)
-EOD,);
+EOD, );
             $insertStmt->execute(['key_data' => $keyData]);
 
             if ($format === 'json') {

--- a/src/Command/Job/GetCommand.php
+++ b/src/Command/Job/GetCommand.php
@@ -31,7 +31,8 @@ class GetCommand extends MultiFlexiCommand
             ->setName('job:get')
             ->setDescription('Get a job by ID')
             ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
-            ->addOption('id', null, InputOption::VALUE_REQUIRED, 'Job ID');
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, 'Job ID')
+            ->addOption('fields', null, InputOption::VALUE_OPTIONAL, 'Comma-separated list of fields to display');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/Job/ListCommand.php
+++ b/src/Command/Job/ListCommand.php
@@ -64,6 +64,7 @@ class ListCommand extends MultiFlexiCommand
                     $query->where('begin IS NULL')->where('exitcode IS NULL');
 
                     break;
+
                 default:
                     // unknown status value — ignore filter
                     break;


### PR DESCRIPTION
## Summary
- The `--fields` option was used in `execute()` of `job:get` but never declared in `configure()`, causing the error: `The "fields" option does not exist.`
- Added `->addOption('fields', ...)` to `GetCommand::configure()` to match the existing usage

## Test plan
- [ ] Run `multiflexi-cli job:get --id <id>` — should work without error
- [ ] Run `multiflexi-cli job:get --id <id> --fields name,status` — should filter output to specified fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `job:get` command accepts an optional `--fields` parameter to display only the specified job attributes (comma-separated) in both JSON and text output.

* **Chores**
  * Added development tooling and testing dependencies.
  * Updated application metadata and added/install icon assets for packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->