### PR TITLE
fix: tolerate missing shell completion support across distros

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -45,9 +45,9 @@ override_dh_install:
 	sed -i "s|require_once __DIR__.'/../vendor/autoload.php';|require_once '/tmp/multiflexi-cli-build-autoload.php';|" \
 	    /tmp/multiflexi-cli-build.php
 	mkdir -p debian/multiflexi-cli/usr/share/bash-completion/completions
-	php /tmp/multiflexi-cli-build.php completion bash > debian/multiflexi-cli/usr/share/bash-completion/completions/multiflexi-cli
+	php /tmp/multiflexi-cli-build.php completion bash > debian/multiflexi-cli/usr/share/bash-completion/completions/multiflexi-cli || true
 	mkdir -p debian/multiflexi-cli/usr/share/zsh-completion/completions
-	php /tmp/multiflexi-cli-build.php completion zsh > debian/multiflexi-cli/usr/share/zsh-completion/completions/multiflexi-cli
+	php /tmp/multiflexi-cli-build.php completion zsh > debian/multiflexi-cli/usr/share/zsh-completion/completions/multiflexi-cli || true
 	rm -f /tmp/multiflexi-cli-build.php /tmp/multiflexi-cli-build-autoload.php
 	install -m0755 -d debian/multiflexi-cli/usr/share/pkg-php-tools/autoloaders
 	echo 'deb multiflexi-cli multiflexi-cli/autoload.php' > debian/multiflexi-cli/usr/share/pkg-php-tools/autoloaders/multiflexi-cli


### PR DESCRIPTION
## Summary

- Bookworm ships Symfony Console that only supports `bash` completion — `completion zsh` exits non-zero and breaks the build
- Jammy ships an even older version with **no** shell completion support at all (`supported shells: ""`) — even `completion bash` fails
- Trixie, noble, and resolute have newer Symfony with full bash+zsh support and generate completions correctly
- Adding `|| true` to both completion commands lets each distro produce what it can without failing the build

## Test plan

- [ ] Trigger a new Jenkins build and confirm all five distros (bookworm, trixie, jammy, noble, resolute) complete `override_dh_install` without error
- [ ] Verify bash completion file is present in packages built on bookworm/trixie/noble/resolute
- [ ] Verify zsh completion file is present in packages built on trixie/noble/resolute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build resilience by allowing shell completion generation to fail without interrupting the packaging process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/multiflexi-cli/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->