### PR TITLE
feat: bump version to 2.5.4; add run-template credential assignment commands

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,14 @@
-multiflexi-cli (2.5.3) UNRELEASED; urgency=medium
+multiflexi-cli (2.5.4) UNRELEASED; urgency=medium
+
+  * Add run-template:assign-credential command
+  * Add run-template:unassign-credential command
+  * Add run-template:list-credentials command
+  * Update tests for credential assignment commands
+  * Update documentation for credential assignment commands
+
+ -- Vítězslav Dvořák <info@vitexsoftware.cz>  Mon, 26 May 2026 00:00:00 +0200
+
+multiflexi-cli (2.5.3) stable; urgency=medium
 
   * Add --env option to run-template:schedule for one-time env overrides
     that are passed to the job but not saved to the run-template

--- a/debian/multiflexi-cli.1
+++ b/debian/multiflexi-cli.1
@@ -42,6 +42,24 @@ Options: --id, --schedule_time, --executor, --env (repeatable, one-time override
 Note: Only run-templates with active=1 can be scheduled.
 .RE
 .TP
+.B run-template:assign-credential
+Assign a credential to a run template.
+.RS
+Options: --runtemplate_id, --credential_id, --format
+.RE
+.TP
+.B run-template:unassign-credential
+Remove a credential assignment from a run template.
+.RS
+Options: --runtemplate_id, --credential_id, --format
+.RE
+.TP
+.B run-template:list-credentials
+List all credentials assigned to a run template.
+.RS
+Options: --runtemplate_id, --format
+.RE
+.TP
 .B job:list / job:get / job:create / job:update / job:delete
 Manage jobs.
 .RS
@@ -222,6 +240,15 @@ Schedule a run-template immediately:
 .TP
 Schedule with a one-time environment override (not saved to run-template):
 .B multiflexi-cli run-template:schedule --id=167 --env=IMPORT_SCOPE=2025-11-01>2026-01-07
+.TP
+Assign a credential to a run template:
+.B multiflexi-cli run-template:assign-credential --runtemplate_id=5 --credential_id=12
+.TP
+Remove a credential assignment from a run template:
+.B multiflexi-cli run-template:unassign-credential --runtemplate_id=5 --credential_id=12
+.TP
+List credentials assigned to a run template:
+.B multiflexi-cli run-template:list-credentials --runtemplate_id=5
 .TP
 List failed jobs:
 .B multiflexi-cli job:list --status=failed

--- a/doc/multiflexi-cli.rst
+++ b/doc/multiflexi-cli.rst
@@ -51,7 +51,7 @@ The MultiFlexi CLI provides the following main commands:
 - **company:\***         - Manage companies and their settings
 - **company-app:\***     - Manage company-application relations (list, assign, unassign)
 - **job:\***             - Manage job execution and monitoring
-- **run-template:\***    - Manage run templates and scheduling
+- **run-template:\***    - Manage run templates, scheduling, and credential assignment
 - **user:\***            - User account management
 - **user-erasure:\***    - GDPR user data erasure management
 - **token:\***           - API token management
@@ -290,7 +290,7 @@ Examples:
 run-template
 ------------
 
-Manage run templates (list, get, create, update, delete, schedule).
+Manage run templates (list, get, create, update, delete, schedule, and credential assignment).
 
 .. code-block:: bash
 
@@ -300,6 +300,9 @@ Manage run templates (list, get, create, update, delete, schedule).
     multiflexi-cli run-template:update --id=<id> [options]
     multiflexi-cli run-template:delete --id=<id>
     multiflexi-cli run-template:schedule --id=<id> [options]
+    multiflexi-cli run-template:assign-credential --runtemplate_id=<id> --credential_id=<id> [options]
+    multiflexi-cli run-template:unassign-credential --runtemplate_id=<id> --credential_id=<id> [options]
+    multiflexi-cli run-template:list-credentials --runtemplate_id=<id> [options]
 
 Common options:
   --id           RunTemplate ID
@@ -315,6 +318,10 @@ Schedule-specific options:
   --env          One-time environment override key=value — passed to the job but NOT saved to run-template (repeatable)
   --schedule_time Schedule time (Y-m-d H:i:s or "now", default: now)
   --executor     Executor to use for this job
+
+Credential assignment options:
+  --runtemplate_id  RunTemplate ID
+  --credential_id   Credential ID
 
 .. note::
 
@@ -336,6 +343,16 @@ Examples:
 
     # Regular schedule with future time:
     multiflexi-cli run-template:schedule --id=123 --schedule_time="2025-07-01 10:00:00" --executor=Native --env=FOO=bar --env=BAZ=qux
+
+    # Assign a credential to a run template:
+    multiflexi-cli run-template:assign-credential --runtemplate_id=5 --credential_id=12
+
+    # Remove a credential assignment from a run template:
+    multiflexi-cli run-template:unassign-credential --runtemplate_id=5 --credential_id=12
+
+    # List all credentials assigned to a run template:
+    multiflexi-cli run-template:list-credentials --runtemplate_id=5
+    multiflexi-cli run-template:list-credentials --runtemplate_id=5 --format=json
 
 user
 ----

--- a/src/Command/RunTemplate/AssignCredentialCommand.php
+++ b/src/Command/RunTemplate/AssignCredentialCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the MultiFlexi package
+ *
+ * https://multiflexi.eu/
+ *
+ * (c) Vítězslav Dvořák <http://vitexsoftware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MultiFlexi\Cli\Command\RunTemplate;
+
+use MultiFlexi\Credential;
+use MultiFlexi\CredentialType;
+use MultiFlexi\RunTplCreds;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class AssignCredentialCommand extends BaseCommand
+{
+    protected static $defaultName = 'run-template:assign-credential';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('run-template:assign-credential')
+            ->setDescription('Assign a credential to a run template')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
+            ->addOption('runtemplate_id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID')
+            ->addOption('credential_id', null, InputOption::VALUE_REQUIRED, 'Credential ID');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $format = strtolower($input->getOption('format'));
+
+        $runtemplateId = $input->getOption('runtemplate_id');
+        $credentialId = $input->getOption('credential_id');
+
+        if (empty($runtemplateId) || !is_numeric($runtemplateId)) {
+            $msg = 'Missing or invalid --runtemplate_id';
+            $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
+
+            return self::FAILURE;
+        }
+
+        if (empty($credentialId) || !is_numeric($credentialId)) {
+            $msg = 'Missing or invalid --credential_id';
+            $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
+
+            return self::FAILURE;
+        }
+
+        $runtemplateId = (int) $runtemplateId;
+        $credentialId = (int) $credentialId;
+
+        $credential = new Credential($credentialId);
+
+        if (!$credential->getMyKey()) {
+            $msg = "Credential #{$credentialId} not found";
+            $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
+
+            return self::FAILURE;
+        }
+
+        $credentialTypeId = (int) $credential->getDataValue('credential_type_id');
+        $credentialType = new CredentialType($credentialTypeId);
+        $prototype = (string) $credentialType->getDataValue('prototype');
+
+        $rtCreds = new RunTplCreds();
+        $rtCreds->bind($runtemplateId, $credentialId, $prototype);
+
+        if ($format === 'json') {
+            $output->writeln(json_encode([
+                'status' => 'ok',
+                'runtemplate_id' => $runtemplateId,
+                'credential_id' => $credentialId,
+                'prototype' => $prototype,
+            ], \JSON_PRETTY_PRINT));
+        } else {
+            $output->writeln("Credential #{$credentialId} assigned to RunTemplate #{$runtemplateId}");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Command/RunTemplate/ListCredentialsCommand.php
+++ b/src/Command/RunTemplate/ListCredentialsCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the MultiFlexi package
+ *
+ * https://multiflexi.eu/
+ *
+ * (c) Vítězslav Dvořák <http://vitexsoftware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MultiFlexi\Cli\Command\RunTemplate;
+
+use MultiFlexi\RunTemplate;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCredentialsCommand extends BaseCommand
+{
+    protected static $defaultName = 'run-template:list-credentials';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('run-template:list-credentials')
+            ->setDescription('List credentials assigned to a run template')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
+            ->addOption('runtemplate_id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $format = strtolower($input->getOption('format'));
+
+        $runtemplateId = $input->getOption('runtemplate_id');
+
+        if (empty($runtemplateId) || !is_numeric($runtemplateId)) {
+            $msg = 'Missing or invalid --runtemplate_id';
+            $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
+
+            return self::FAILURE;
+        }
+
+        $rt = new RunTemplate((int) $runtemplateId);
+        $credentials = $rt->getCredentialsAssigned();
+
+        if ($format === 'json') {
+            $output->writeln(json_encode(array_values($credentials), \JSON_PRETTY_PRINT));
+        } else {
+            $output->writeln(self::outputTable(array_values($credentials)));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Command/RunTemplate/UnassignCredentialCommand.php
+++ b/src/Command/RunTemplate/UnassignCredentialCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the MultiFlexi package
+ *
+ * https://multiflexi.eu/
+ *
+ * (c) Vítězslav Dvořák <http://vitexsoftware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MultiFlexi\Cli\Command\RunTemplate;
+
+use MultiFlexi\RunTplCreds;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UnassignCredentialCommand extends BaseCommand
+{
+    protected static $defaultName = 'run-template:unassign-credential';
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('run-template:unassign-credential')
+            ->setDescription('Remove a credential assignment from a run template')
+            ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
+            ->addOption('runtemplate_id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID')
+            ->addOption('credential_id', null, InputOption::VALUE_REQUIRED, 'Credential ID');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $format = strtolower($input->getOption('format'));
+
+        $runtemplateId = $input->getOption('runtemplate_id');
+        $credentialId = $input->getOption('credential_id');
+
+        if (empty($runtemplateId) || !is_numeric($runtemplateId)) {
+            $msg = 'Missing or invalid --runtemplate_id';
+            $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
+
+            return self::FAILURE;
+        }
+
+        if (empty($credentialId) || !is_numeric($credentialId)) {
+            $msg = 'Missing or invalid --credential_id';
+            $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
+
+            return self::FAILURE;
+        }
+
+        $runtemplateId = (int) $runtemplateId;
+        $credentialId = (int) $credentialId;
+
+        $rtCreds = new RunTplCreds();
+        $result = $rtCreds->unbind($runtemplateId, $credentialId);
+
+        if ($format === 'json') {
+            $output->writeln(json_encode([
+                'status' => $result ? 'ok' : 'not_found',
+                'runtemplate_id' => $runtemplateId,
+                'credential_id' => $credentialId,
+            ], \JSON_PRETTY_PRINT));
+        } else {
+            if ($result) {
+                $output->writeln("Credential #{$credentialId} unassigned from RunTemplate #{$runtemplateId}");
+            } else {
+                $output->writeln("<comment>No assignment found for Credential #{$credentialId} on RunTemplate #{$runtemplateId}</comment>");
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/multiflexi-cli.php
+++ b/src/multiflexi-cli.php
@@ -87,11 +87,14 @@ use MultiFlexi\Cli\Command\Queue\FixCommand as QueueFixCommand;
 use MultiFlexi\Cli\Command\Queue\ListCommand as QueueListCommand;
 use MultiFlexi\Cli\Command\Queue\OverviewCommand as QueueOverviewCommand;
 use MultiFlexi\Cli\Command\Queue\TruncateCommand as QueueTruncateCommand;
+use MultiFlexi\Cli\Command\RunTemplate\AssignCredentialCommand as RunTemplateAssignCredentialCommand;
 use MultiFlexi\Cli\Command\RunTemplate\CreateCommand as RunTemplateCreateCommand;
 use MultiFlexi\Cli\Command\RunTemplate\DeleteCommand as RunTemplateDeleteCommand;
 use MultiFlexi\Cli\Command\RunTemplate\GetCommand as RunTemplateGetCommand;
 use MultiFlexi\Cli\Command\RunTemplate\ListCommand as RunTemplateListCommand;
+use MultiFlexi\Cli\Command\RunTemplate\ListCredentialsCommand as RunTemplateListCredentialsCommand;
 use MultiFlexi\Cli\Command\RunTemplate\ScheduleCommand as RunTemplateScheduleCommand;
+use MultiFlexi\Cli\Command\RunTemplate\UnassignCredentialCommand as RunTemplateUnassignCredentialCommand;
 use MultiFlexi\Cli\Command\RunTemplate\UpdateCommand as RunTemplateUpdateCommand;
 use MultiFlexi\Cli\Command\StatusCommand;
 use MultiFlexi\Cli\Command\TelemetryTestCommand;
@@ -240,6 +243,9 @@ $application->add(new RunTemplateCreateCommand());
 $application->add(new RunTemplateUpdateCommand());
 $application->add(new RunTemplateDeleteCommand());
 $application->add(new RunTemplateScheduleCommand());
+$application->add(new RunTemplateAssignCredentialCommand());
+$application->add(new RunTemplateUnassignCredentialCommand());
+$application->add(new RunTemplateListCredentialsCommand());
 
 // Token
 $application->add(new TokenListCommand());

--- a/tests/src/Command/RunTemplateTest.php
+++ b/tests/src/Command/RunTemplateTest.php
@@ -15,15 +15,24 @@ declare(strict_types=1);
 
 namespace Test\MultiFlexi\Cli\Command;
 
+use MultiFlexi\Cli\Command\RunTemplate\AssignCredentialCommand;
+use MultiFlexi\Cli\Command\RunTemplate\ListCredentialsCommand;
 use MultiFlexi\Cli\Command\RunTemplate\ScheduleCommand;
+use MultiFlexi\Cli\Command\RunTemplate\UnassignCredentialCommand;
 
 class RunTemplateTest extends \PHPUnit\Framework\TestCase
 {
     protected ScheduleCommand $schedule;
+    protected AssignCredentialCommand $assignCredential;
+    protected UnassignCredentialCommand $unassignCredential;
+    protected ListCredentialsCommand $listCredentials;
 
     protected function setUp(): void
     {
         $this->schedule = new ScheduleCommand();
+        $this->assignCredential = new AssignCredentialCommand();
+        $this->unassignCredential = new UnassignCredentialCommand();
+        $this->listCredentials = new ListCredentialsCommand();
     }
 
     public function testScheduleCommandHasEnvOption(): void
@@ -56,5 +65,68 @@ class RunTemplateTest extends \PHPUnit\Framework\TestCase
         $definition = $this->schedule->getDefinition();
         $option = $definition->getOption('config');
         $this->assertTrue($option->isArray(), '--config must accept multiple values (VALUE_IS_ARRAY)');
+    }
+
+    public function testAssignCredentialCommandName(): void
+    {
+        $this->assertSame('run-template:assign-credential', $this->assignCredential->getName());
+    }
+
+    public function testAssignCredentialCommandHasRuntemplateIdOption(): void
+    {
+        $definition = $this->assignCredential->getDefinition();
+        $this->assertTrue($definition->hasOption('runtemplate_id'), '--runtemplate_id option must be defined on run-template:assign-credential');
+    }
+
+    public function testAssignCredentialCommandHasCredentialIdOption(): void
+    {
+        $definition = $this->assignCredential->getDefinition();
+        $this->assertTrue($definition->hasOption('credential_id'), '--credential_id option must be defined on run-template:assign-credential');
+    }
+
+    public function testAssignCredentialCommandHasFormatOption(): void
+    {
+        $definition = $this->assignCredential->getDefinition();
+        $this->assertTrue($definition->hasOption('format'), '--format option must be defined on run-template:assign-credential');
+    }
+
+    public function testUnassignCredentialCommandName(): void
+    {
+        $this->assertSame('run-template:unassign-credential', $this->unassignCredential->getName());
+    }
+
+    public function testUnassignCredentialCommandHasRuntemplateIdOption(): void
+    {
+        $definition = $this->unassignCredential->getDefinition();
+        $this->assertTrue($definition->hasOption('runtemplate_id'), '--runtemplate_id option must be defined on run-template:unassign-credential');
+    }
+
+    public function testUnassignCredentialCommandHasCredentialIdOption(): void
+    {
+        $definition = $this->unassignCredential->getDefinition();
+        $this->assertTrue($definition->hasOption('credential_id'), '--credential_id option must be defined on run-template:unassign-credential');
+    }
+
+    public function testUnassignCredentialCommandHasFormatOption(): void
+    {
+        $definition = $this->unassignCredential->getDefinition();
+        $this->assertTrue($definition->hasOption('format'), '--format option must be defined on run-template:unassign-credential');
+    }
+
+    public function testListCredentialsCommandName(): void
+    {
+        $this->assertSame('run-template:list-credentials', $this->listCredentials->getName());
+    }
+
+    public function testListCredentialsCommandHasRuntemplateIdOption(): void
+    {
+        $definition = $this->listCredentials->getDefinition();
+        $this->assertTrue($definition->hasOption('runtemplate_id'), '--runtemplate_id option must be defined on run-template:list-credentials');
+    }
+
+    public function testListCredentialsCommandHasFormatOption(): void
+    {
+        $definition = $this->listCredentials->getDefinition();
+        $this->assertTrue($definition->hasOption('format'), '--format option must be defined on run-template:list-credentials');
     }
 }


### PR DESCRIPTION
## Summary

- Add `run-template:assign-credential` command to assign a credential to a run template
- Add `run-template:unassign-credential` command to remove a credential assignment from a run template
- Add `run-template:list-credentials` command to list all credentials assigned to a run template
- Bump version to 2.5.4 in `debian/changelog`
- Add 11 new PHPUnit tests covering command names and option definitions for all three new commands
- Update `doc/multiflexi-cli.rst` with new commands, options, and examples
- Update `debian/multiflexi-cli.1` man page with new commands and examples

## Test plan

- [ ] Run `vendor/bin/phpunit tests/src/Command/RunTemplateTest.php` — all 16 tests pass
- [ ] Run `./cli.sh describe` and confirm `run-template:assign-credential`, `run-template:unassign-credential`, `run-template:list-credentials` appear in output
- [ ] Review RST doc changes in `doc/multiflexi-cli.rst`
- [ ] Review man page changes in `debian/multiflexi-cli.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential assignment management for run templates: assign, unassign, and list credentials assigned to templates.

* **Documentation**
  * Updated CLI documentation and man pages with new credential assignment commands and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/multiflexi-cli/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->