### PR TITLE
fix: rename --runtemplate_id to --id on credential commands for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.5] - 2026-05-28
+
+### Fixed
+- `run-template:assign-credential`, `run-template:unassign-credential`, and `run-template:list-credentials` now use `--id` (not `--runtemplate_id`) for the RunTemplate ID, consistent with all other `run-template:*` commands
+
+## [2.5.4] - 2026-05-26
+
+### Added
+- `run-template:assign-credential --id <id> --credential_id <cid>` — assign a credential to a run template
+- `run-template:unassign-credential --id <id> --credential_id <cid>` — remove a credential assignment from a run template
+- `run-template:list-credentials --id <id>` — list credentials assigned to a run template
+
 ## [2.5.3] - 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ multiflexi-cli <command> [options]
 | `run-template:list` | List run templates |
 | `run-template:schedule --id <id>` | Schedule a run template as a job |
 | `run-template:schedule --id <id> --env KEY=VALUE` | Schedule with one-time env override |
+| `run-template:list-credentials --id <id>` | List credentials assigned to a run template |
+| `run-template:assign-credential --id <id> --credential_id <cid>` | Assign a credential to a run template |
+| `run-template:unassign-credential --id <id> --credential_id <cid>` | Remove a credential from a run template |
 | `job:list` | List jobs |
 | `job:get --id <id>` | Get job details |
 | `job:status --id <id>` | Get job status |
@@ -78,6 +81,9 @@ multiflexi-cli application:delete --id 456
 multiflexi-cli run-template:list
 multiflexi-cli run-template:schedule --id 167
 multiflexi-cli run-template:schedule --id 167 --env IMPORT_SCOPE=2025-11-01>2026-01-07
+multiflexi-cli run-template:list-credentials --id 186 --format json
+multiflexi-cli run-template:assign-credential --id 186 --credential_id 12
+multiflexi-cli run-template:unassign-credential --id 186 --credential_id 12
 
 # Jobs
 multiflexi-cli job:list

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+multiflexi-cli (2.5.5) UNRELEASED; urgency=medium
+
+  * Fix: rename --runtemplate_id to --id on run-template:assign-credential,
+    run-template:unassign-credential, and run-template:list-credentials
+    to be consistent with all other run-template:* commands
+  * Update tests: replace --runtemplate_id assertions with --id
+  * Update documentation with corrected option names
+
+ -- Vítězslav Dvořák <info@vitexsoftware.cz>  Wed, 28 May 2026 00:00:00 +0200
+
 multiflexi-cli (2.5.4) UNRELEASED; urgency=medium
 
   * Add run-template:assign-credential command

--- a/src/Command/RunTemplate/AssignCredentialCommand.php
+++ b/src/Command/RunTemplate/AssignCredentialCommand.php
@@ -32,7 +32,7 @@ class AssignCredentialCommand extends BaseCommand
             ->setName('run-template:assign-credential')
             ->setDescription('Assign a credential to a run template')
             ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
-            ->addOption('runtemplate_id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID')
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID')
             ->addOption('credential_id', null, InputOption::VALUE_REQUIRED, 'Credential ID');
     }
 
@@ -40,11 +40,11 @@ class AssignCredentialCommand extends BaseCommand
     {
         $format = strtolower($input->getOption('format'));
 
-        $runtemplateId = $input->getOption('runtemplate_id');
+        $runtemplateId = $input->getOption('id');
         $credentialId = $input->getOption('credential_id');
 
         if (empty($runtemplateId) || !is_numeric($runtemplateId)) {
-            $msg = 'Missing or invalid --runtemplate_id';
+            $msg = 'Missing or invalid --id';
             $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
 
             return self::FAILURE;

--- a/src/Command/RunTemplate/ListCredentialsCommand.php
+++ b/src/Command/RunTemplate/ListCredentialsCommand.php
@@ -30,17 +30,17 @@ class ListCredentialsCommand extends BaseCommand
             ->setName('run-template:list-credentials')
             ->setDescription('List credentials assigned to a run template')
             ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
-            ->addOption('runtemplate_id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID');
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $format = strtolower($input->getOption('format'));
 
-        $runtemplateId = $input->getOption('runtemplate_id');
+        $runtemplateId = $input->getOption('id');
 
         if (empty($runtemplateId) || !is_numeric($runtemplateId)) {
-            $msg = 'Missing or invalid --runtemplate_id';
+            $msg = 'Missing or invalid --id';
             $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
 
             return self::FAILURE;

--- a/src/Command/RunTemplate/UnassignCredentialCommand.php
+++ b/src/Command/RunTemplate/UnassignCredentialCommand.php
@@ -30,7 +30,7 @@ class UnassignCredentialCommand extends BaseCommand
             ->setName('run-template:unassign-credential')
             ->setDescription('Remove a credential assignment from a run template')
             ->addOption('format', 'f', InputOption::VALUE_OPTIONAL, 'Output format: text or json', 'text')
-            ->addOption('runtemplate_id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID')
+            ->addOption('id', null, InputOption::VALUE_REQUIRED, 'RunTemplate ID')
             ->addOption('credential_id', null, InputOption::VALUE_REQUIRED, 'Credential ID');
     }
 
@@ -38,11 +38,11 @@ class UnassignCredentialCommand extends BaseCommand
     {
         $format = strtolower($input->getOption('format'));
 
-        $runtemplateId = $input->getOption('runtemplate_id');
+        $runtemplateId = $input->getOption('id');
         $credentialId = $input->getOption('credential_id');
 
         if (empty($runtemplateId) || !is_numeric($runtemplateId)) {
-            $msg = 'Missing or invalid --runtemplate_id';
+            $msg = 'Missing or invalid --id';
             $output->writeln($format === 'json' ? json_encode(['status' => 'error', 'message' => $msg]) : "<error>{$msg}</error>");
 
             return self::FAILURE;

--- a/tests/src/Command/RunTemplateTest.php
+++ b/tests/src/Command/RunTemplateTest.php
@@ -72,10 +72,10 @@ class RunTemplateTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('run-template:assign-credential', $this->assignCredential->getName());
     }
 
-    public function testAssignCredentialCommandHasRuntemplateIdOption(): void
+    public function testAssignCredentialCommandHasIdOption(): void
     {
         $definition = $this->assignCredential->getDefinition();
-        $this->assertTrue($definition->hasOption('runtemplate_id'), '--runtemplate_id option must be defined on run-template:assign-credential');
+        $this->assertTrue($definition->hasOption('id'), '--id option must be defined on run-template:assign-credential');
     }
 
     public function testAssignCredentialCommandHasCredentialIdOption(): void
@@ -95,10 +95,10 @@ class RunTemplateTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('run-template:unassign-credential', $this->unassignCredential->getName());
     }
 
-    public function testUnassignCredentialCommandHasRuntemplateIdOption(): void
+    public function testUnassignCredentialCommandHasIdOption(): void
     {
         $definition = $this->unassignCredential->getDefinition();
-        $this->assertTrue($definition->hasOption('runtemplate_id'), '--runtemplate_id option must be defined on run-template:unassign-credential');
+        $this->assertTrue($definition->hasOption('id'), '--id option must be defined on run-template:unassign-credential');
     }
 
     public function testUnassignCredentialCommandHasCredentialIdOption(): void
@@ -118,10 +118,10 @@ class RunTemplateTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('run-template:list-credentials', $this->listCredentials->getName());
     }
 
-    public function testListCredentialsCommandHasRuntemplateIdOption(): void
+    public function testListCredentialsCommandHasIdOption(): void
     {
         $definition = $this->listCredentials->getDefinition();
-        $this->assertTrue($definition->hasOption('runtemplate_id'), '--runtemplate_id option must be defined on run-template:list-credentials');
+        $this->assertTrue($definition->hasOption('id'), '--id option must be defined on run-template:list-credentials');
     }
 
     public function testListCredentialsCommandHasFormatOption(): void


### PR DESCRIPTION
## Summary
- `run-template:assign-credential`, `run-template:unassign-credential`, and `run-template:list-credentials` were using `--runtemplate_id` as the RunTemplate ID option
- All other `run-template:*` commands use `--id` — this was an inconsistency introduced in 2.5.4
- Renamed the option to `--id` across all three commands, updated tests and documentation, bumped version to 2.5.5

## Test plan
- [ ] `phpunit tests/src/Command/RunTemplateTest.php` passes (16/16 assertions)
- [ ] `multiflexi-cli run-template:list-credentials --id 186 --format json` works
- [ ] `multiflexi-cli run-template:assign-credential --id 186 --credential_id 12` works
- [ ] `multiflexi-cli run-template:unassign-credential --id 186 --credential_id 12` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `run-template:assign-credential`, `run-template:unassign-credential`, and `run-template:list-credentials` commands now use `--id` instead of `--runtemplate_id` for specifying the RunTemplate ID parameter.

* **Documentation**
  * Updated documentation with examples for run-template credential management operations, including listing, assigning, and unassigning credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/multiflexi-cli/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->